### PR TITLE
Update the deep-histopath to be latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN pip install -r requirements.txt
 RUN cd /workspace && \
     git clone https://github.com/codait/deep-histopath && \
     cd deep-histopath && \
-    git checkout e0c93c3543830a0ee07ad9408e844465f045781c && \
     cd ../ && \
     cp -R deep-histopath/. .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip install -r requirements.txt
 RUN cd /workspace && \
     git clone https://github.com/codait/deep-histopath && \
     cd deep-histopath && \
+    git checkout c8baf8d47b6c08c0f6c7b1fb6d5dd6b77e711c33 && \
     cd ../ && \
     cp -R deep-histopath/. .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14.1
-tensorflow==1.9.0
+tensorflow==1.12.2
 Pillow==6.0.0
 h5py==2.9.0
 openslide-python==1.1.1


### PR DESCRIPTION
The old version of deep-histopath repo will not work with TF-1.12.2 due to the API change in Keras: `ImportError: cannot import name 'get_source_inputs'`. The latest deep-histopath could work with TF-1.12.2, so we can remove `git check ......`.   With this PR merged, we can merge #24.